### PR TITLE
Adapt Type Mappings before binding

### DIFF
--- a/src/Npgsql/NpgsqlDatabaseInfo.cs
+++ b/src/Npgsql/NpgsqlDatabaseInfo.cs
@@ -28,6 +28,7 @@ using System.Data.Common;
 using System.Runtime.InteropServices.ComTypes;
 using System.Threading.Tasks;
 using Npgsql.PostgresTypes;
+using Npgsql.TypeMapping;
 
 namespace Npgsql
 {
@@ -204,6 +205,12 @@ namespace Npgsql
         /// </summary>
         /// <returns></returns>
         protected abstract IEnumerable<PostgresType> GetTypes();
+
+        /// <summary>
+        /// Adapts the type mappings for this database.
+        /// </summary>
+        /// <param name="mappings">The mappings that are about the be bound.</param>
+        protected internal virtual void AdaptTypeMappings(IDictionary<string, NpgsqlTypeMapping> mappings) { }
 
         #endregion Types
 

--- a/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
@@ -246,6 +246,9 @@ namespace Npgsql.TypeMapping
 
         void BindTypes()
         {
+            // Prepare the registered type mappings for the DBMS currently in use.
+            DatabaseInfo?.AdaptTypeMappings(Mappings);
+
             foreach (var mapping in Mappings.Values)
                 BindType(mapping, _connector, false);
 


### PR DESCRIPTION
Allow NpgsqlDatabaseInfo derived classes to adapt type mappings before they are bound